### PR TITLE
Terminal output of UUID and Name during scan, plus README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ npm install -g browserify
 # Install local deps
 npm install
 
+# Run gulp 
+gulp
+
 # Configure app to run the Yaw-Pitch-Roll section, see localhost:4200/ after starting the server.
 npm config set imuduino-3js:type IMUduino_Bluetooth_UART_YawPitchRoll
 

--- a/lib/imuduino.js
+++ b/lib/imuduino.js
@@ -24,7 +24,7 @@ function Imuduino(peripheral_id, packet_type) {
   this.buffer = []
 
   noble.on('discover', function (peripheral) {
-    console.log('...Discoverd peripheral UUID:', peripheral.uuid, peripheral.advertisment.localName);
+    console.log('...Discoverd peripheral UUID:', peripheral.uuid, peripheral.advertisement.localName);
 
     if (peripheral.uuid == peripheral_id) {
       self.emit('peripheralDiscovered', peripheral)

--- a/lib/imuduino.js
+++ b/lib/imuduino.js
@@ -24,7 +24,7 @@ function Imuduino(peripheral_id, packet_type) {
   this.buffer = []
 
   noble.on('discover', function (peripheral) {
-    console.log('...Discoverd peripheral UUID:', peripheral.uuid);
+    console.log('...Discoverd peripheral UUID:', peripheral.uuid, peripher.advertisme.localName);
 
     if (peripheral.uuid == peripheral_id) {
       self.emit('peripheralDiscovered', peripheral)

--- a/lib/imuduino.js
+++ b/lib/imuduino.js
@@ -24,7 +24,7 @@ function Imuduino(peripheral_id, packet_type) {
   this.buffer = []
 
   noble.on('discover', function (peripheral) {
-    console.log('...Discoverd peripheral UUID:', peripheral.uuid, peripher.advertisme.localName);
+    console.log('...Discoverd peripheral UUID:', peripheral.uuid, peripheral.advertisment.localName);
 
     if (peripheral.uuid == peripheral_id) {
       self.emit('peripheralDiscovered', peripheral)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "keypress": "^0.2.1",
     "lodash": "^3.9.3",
     "noble": "^1.0.1",
-    "socket.io": "^1.3.5"
+    "socket.io": "^1.3.5",
+    "three": "^0.71.0"
   },
   "devDependencies": {
     "d3": "^3.5.5",


### PR DESCRIPTION
Community member contributions. The scan output of the UUID(s) found now output the peripheral name if available. README has been updated to include missing setup step (gulp tool).
