### PR TITLE
Scanning should stop once UUID is connected.

### DIFF
--- a/lib/imuduino.js
+++ b/lib/imuduino.js
@@ -29,6 +29,8 @@ function Imuduino(peripheral_id, packet_type) {
     if (peripheral.uuid == peripheral_id) {
       self.emit('peripheralDiscovered', peripheral)
       self.connect(peripheral)
+
+      noble.stopScanning();
     }
   })
   noble.on('stateChange', function (state) {

--- a/lib/service-info.js
+++ b/lib/service-info.js
@@ -1,6 +1,6 @@
 module.exports = {
-  peripheralUUID: 'c60b7f7a1095',
-  serviceUUID:      '6e400001b5a3f393e0a9e50e24dcca9e',
+  peripheralUUID: '58923d1d582045d8b66553ee22d27184',
+  serviceUUID: '6e400001b5a3f393e0a9e50e24dcca9e',
   rxCharacteristic: '6e400003b5a3f393e0a9e50e24dcca9e',
   txCharacteristic: '6e400002b5a3f393e0a9e50e24dcca9e'
 };

--- a/lib/service-info.js
+++ b/lib/service-info.js
@@ -1,6 +1,6 @@
 module.exports = {
-  peripheralUUID: '58923d1d582045d8b66553ee22d27184',
-  serviceUUID: '6e400001b5a3f393e0a9e50e24dcca9e',
+  peripheralUUID: 'c60b7f7a1095',
+  serviceUUID:      '6e400001b5a3f393e0a9e50e24dcca9e',
   rxCharacteristic: '6e400003b5a3f393e0a9e50e24dcca9e',
   txCharacteristic: '6e400002b5a3f393e0a9e50e24dcca9e'
 };


### PR DESCRIPTION
As we discovered while at NodeBots day in SF, the underlying BLE interface can become sluggish and even halt when scanning is left active, and the surrounding area is saturated with many bluetooth low energy devices. 

Device scanning should stop once our specified UUID is found, and the device is connected to (since there is no point in continuing the search once our device is found).
